### PR TITLE
Fix broken hairstyle overlay ids

### DIFF
--- a/dda/gfx/MSX++UnDeadPeopleEdition_v2/pngs_normal_character_32x32/character/appearance/hair/hair.json
+++ b/dda/gfx/MSX++UnDeadPeopleEdition_v2/pngs_normal_character_32x32/character/appearance/hair/hair.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "overlay_female_mutation_buzzcut_var_black",
+    "id": "overlay_female_mutation_hair_buzzcut_var_black",
     "fg": [
       "overlay_female_mutation_buzzcut_var_black"
     ],
@@ -8,7 +8,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_blond",
+    "id": "overlay_female_mutation_hair_buzzcut_var_blond",
     "fg": [
       "overlay_female_mutation_buzzcut_var_blond"
     ],
@@ -16,7 +16,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_blue",
+    "id": "overlay_female_mutation_hair_buzzcut_var_blue",
     "fg": [
       "overlay_female_mutation_buzzcut_var_blue"
     ],
@@ -24,7 +24,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_brown",
+    "id": "overlay_female_mutation_hair_buzzcut_var_brown",
     "fg": [
       "overlay_female_mutation_buzzcut_var_brown"
     ],
@@ -32,7 +32,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_gray",
+    "id": "overlay_female_mutation_hair_buzzcut_var_gray",
     "fg": [
       "overlay_female_mutation_buzzcut_var_gray"
     ],
@@ -40,7 +40,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_green",
+    "id": "overlay_female_mutation_hair_buzzcut_var_green",
     "fg": [
       "overlay_female_mutation_buzzcut_var_green"
     ],
@@ -48,7 +48,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_pink",
+    "id": "overlay_female_mutation_hair_buzzcut_var_pink",
     "fg": [
       "overlay_female_mutation_buzzcut_var_pink"
     ],
@@ -56,7 +56,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_purple",
+    "id": "overlay_female_mutation_hair_buzzcut_var_purple",
     "fg": [
       "overlay_female_mutation_buzzcut_var_purple"
     ],
@@ -64,7 +64,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_red",
+    "id": "overlay_female_mutation_hair_buzzcut_var_red",
     "fg": [
       "overlay_female_mutation_buzzcut_var_red"
     ],
@@ -72,7 +72,7 @@
     "rotates": false
   },
   {
-    "id": "overlay_female_mutation_buzzcut_var_white",
+    "id": "overlay_female_mutation_hair_buzzcut_var_white",
     "fg": [
       "overlay_female_mutation_buzzcut_var_white"
     ],
@@ -401,416 +401,6 @@
   },
   {
     "id": [
-      "overlay_male_mutation_braid_var_black",
-      "overlay_female_mutation_braid_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_blond",
-      "overlay_female_mutation_braid_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_blue",
-      "overlay_female_mutation_braid_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_brown",
-      "overlay_female_mutation_braid_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_gray",
-      "overlay_female_mutation_braid_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_green",
-      "overlay_female_mutation_braid_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_pink",
-      "overlay_female_mutation_braid_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_purple",
-      "overlay_female_mutation_braid_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_red",
-      "overlay_female_mutation_braid_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_braid_var_white",
-      "overlay_female_mutation_braid_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_braid_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_black",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_blond",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_blue",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_brown",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_gray",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_green",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_pink",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_purple",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_red",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": "overlay_male_mutation_buzzcut_var_white",
-    "fg": [
-      "overlay_male_mutation_buzzcut_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_black",
-      "overlay_female_mutation_curls_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_blond",
-      "overlay_female_mutation_curls_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_blue",
-      "overlay_female_mutation_curls_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_brown",
-      "overlay_female_mutation_curls_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_gray",
-      "overlay_female_mutation_curls_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_green",
-      "overlay_female_mutation_curls_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_pink",
-      "overlay_female_mutation_curls_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_purple",
-      "overlay_female_mutation_curls_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_red",
-      "overlay_female_mutation_curls_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_curls_var_white",
-      "overlay_female_mutation_curls_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_curls_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_black",
-      "overlay_female_mutation_detective_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_blond",
-      "overlay_female_mutation_detective_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_blue",
-      "overlay_female_mutation_detective_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_brown",
-      "overlay_female_mutation_detective_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_gray",
-      "overlay_female_mutation_detective_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_green",
-      "overlay_female_mutation_detective_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_pink",
-      "overlay_female_mutation_detective_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_purple",
-      "overlay_female_mutation_detective_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_red",
-      "overlay_female_mutation_detective_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_detective_var_white",
-      "overlay_female_mutation_detective_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_detective_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
       "overlay_male_mutation_hair_beaded_var_black",
       "overlay_female_mutation_hair_beaded_var_black"
     ],
@@ -915,6 +505,116 @@
     ],
     "fg": [
       "overlay_mutation_hair_beaded_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_black",
+      "overlay_female_mutation_hair_braid_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_blond",
+      "overlay_female_mutation_hair_braid_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_blue",
+      "overlay_female_mutation_hair_braid_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_brown",
+      "overlay_female_mutation_hair_braid_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_gray",
+      "overlay_female_mutation_hair_braid_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_green",
+      "overlay_female_mutation_hair_braid_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_pink",
+      "overlay_female_mutation_hair_braid_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_purple",
+      "overlay_female_mutation_hair_braid_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_red",
+      "overlay_female_mutation_hair_braid_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_braid_var_white",
+      "overlay_female_mutation_hair_braid_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_braid_var_white"
     ],
     "bg": [],
     "rotates": false
@@ -1030,6 +730,86 @@
     "rotates": false
   },
   {
+    "id": "overlay_male_mutation_hair_buzzcut_var_black",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_blond",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_blue",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_brown",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_gray",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_green",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_pink",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_purple",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_red",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": "overlay_male_mutation_hair_buzzcut_var_white",
+    "fg": [
+      "overlay_male_mutation_buzzcut_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
     "id": "overlay_male_mutation_hair_crewcut_var_black",
     "fg": [
       "overlay_male_mutation_hair_crewcut_var_black"
@@ -1105,6 +885,336 @@
     "id": "overlay_male_mutation_hair_crewcut_var_white",
     "fg": [
       "overlay_male_mutation_hair_crewcut_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_black",
+      "overlay_female_mutation_hair_curls_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_blond",
+      "overlay_female_mutation_hair_curls_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_blue",
+      "overlay_female_mutation_hair_curls_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_brown",
+      "overlay_female_mutation_hair_curls_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_gray",
+      "overlay_female_mutation_hair_curls_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_green",
+      "overlay_female_mutation_hair_curls_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_pink",
+      "overlay_female_mutation_hair_curls_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_purple",
+      "overlay_female_mutation_hair_curls_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_red",
+      "overlay_female_mutation_hair_curls_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_curls_var_white",
+      "overlay_female_mutation_hair_curls_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_curls_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_black",
+      "overlay_female_mutation_hair_detective_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_blond",
+      "overlay_female_mutation_hair_detective_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_blue",
+      "overlay_female_mutation_hair_detective_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_brown",
+      "overlay_female_mutation_hair_detective_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_gray",
+      "overlay_female_mutation_hair_detective_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_green",
+      "overlay_female_mutation_hair_detective_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_pink",
+      "overlay_female_mutation_hair_detective_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_purple",
+      "overlay_female_mutation_hair_detective_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_red",
+      "overlay_female_mutation_hair_detective_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_detective_var_white",
+      "overlay_female_mutation_hair_detective_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_detective_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_black",
+      "overlay_female_mutation_hair_long_over_eye_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_blond",
+      "overlay_female_mutation_hair_long_over_eye_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_blue",
+      "overlay_female_mutation_hair_long_over_eye_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_brown",
+      "overlay_female_mutation_hair_long_over_eye_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_gray",
+      "overlay_female_mutation_hair_long_over_eye_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_green",
+      "overlay_female_mutation_hair_long_over_eye_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_pink",
+      "overlay_female_mutation_hair_long_over_eye_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_purple",
+      "overlay_female_mutation_hair_long_over_eye_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_red",
+      "overlay_female_mutation_hair_long_over_eye_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_long_over_eye_var_white",
+      "overlay_female_mutation_hair_long_over_eye_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_long_over_eye_var_white"
     ],
     "bg": [],
     "rotates": false
@@ -1265,6 +1375,446 @@
     "id": "overlay_male_mutation_hair_medium_var_white",
     "fg": [
       "overlay_male_mutation_hair_medium_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_black",
+      "overlay_female_mutation_hair_messy_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_blond",
+      "overlay_female_mutation_hair_messy_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_blue",
+      "overlay_female_mutation_hair_messy_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_brown",
+      "overlay_female_mutation_hair_messy_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_gray",
+      "overlay_female_mutation_hair_messy_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_green",
+      "overlay_female_mutation_hair_messy_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_pink",
+      "overlay_female_mutation_hair_messy_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_purple",
+      "overlay_female_mutation_hair_messy_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_red",
+      "overlay_female_mutation_hair_messy_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_messy_var_white",
+      "overlay_female_mutation_hair_messy_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_messy_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_black",
+      "overlay_female_mutation_hair_modern_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_blond",
+      "overlay_female_mutation_hair_modern_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_blue",
+      "overlay_female_mutation_hair_modern_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_brown",
+      "overlay_female_mutation_hair_modern_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_gray",
+      "overlay_female_mutation_hair_modern_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_green",
+      "overlay_female_mutation_hair_modern_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_pink",
+      "overlay_female_mutation_hair_modern_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_purple",
+      "overlay_female_mutation_hair_modern_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_red",
+      "overlay_female_mutation_hair_modern_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_modern_var_white",
+      "overlay_female_mutation_hair_modern_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_modern_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_black",
+      "overlay_female_mutation_hair_mullet_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_blond",
+      "overlay_female_mutation_hair_mullet_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_blue",
+      "overlay_female_mutation_hair_mullet_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_brown",
+      "overlay_female_mutation_hair_mullet_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_gray",
+      "overlay_female_mutation_hair_mullet_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_green",
+      "overlay_female_mutation_hair_mullet_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_pink",
+      "overlay_female_mutation_hair_mullet_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_purple",
+      "overlay_female_mutation_hair_mullet_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_red",
+      "overlay_female_mutation_hair_mullet_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_mullet_var_white",
+      "overlay_female_mutation_hair_mullet_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_mullet_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_black",
+      "overlay_female_mutation_hair_ponytail_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_blond",
+      "overlay_female_mutation_hair_ponytail_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_blue",
+      "overlay_female_mutation_hair_ponytail_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_brown",
+      "overlay_female_mutation_hair_ponytail_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_gray",
+      "overlay_female_mutation_hair_ponytail_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_green",
+      "overlay_female_mutation_hair_ponytail_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_pink",
+      "overlay_female_mutation_hair_ponytail_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_purple",
+      "overlay_female_mutation_hair_ponytail_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_red",
+      "overlay_female_mutation_hair_ponytail_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_ponytail_var_white",
+      "overlay_female_mutation_hair_ponytail_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_ponytail_var_white"
     ],
     "bg": [],
     "rotates": false
@@ -1490,6 +2040,226 @@
     "rotates": false
   },
   {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_black",
+      "overlay_female_mutation_hair_short_no_fringe_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_blond",
+      "overlay_female_mutation_hair_short_no_fringe_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_blue",
+      "overlay_female_mutation_hair_short_no_fringe_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_brown",
+      "overlay_female_mutation_hair_short_no_fringe_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_gray",
+      "overlay_female_mutation_hair_short_no_fringe_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_green",
+      "overlay_female_mutation_hair_short_no_fringe_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_pink",
+      "overlay_female_mutation_hair_short_no_fringe_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_purple",
+      "overlay_female_mutation_hair_short_no_fringe_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_red",
+      "overlay_female_mutation_hair_short_no_fringe_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_no_fringe_var_white",
+      "overlay_female_mutation_hair_short_no_fringe_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_short_no_fringe_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_black",
+      "overlay_female_mutation_hair_short_over_eye_var_black"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_black"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_blond",
+      "overlay_female_mutation_hair_short_over_eye_var_blond"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_blond"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_blue",
+      "overlay_female_mutation_hair_short_over_eye_var_blue"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_blue"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_brown",
+      "overlay_female_mutation_hair_short_over_eye_var_brown"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_brown"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_gray",
+      "overlay_female_mutation_hair_short_over_eye_var_gray"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_gray"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_green",
+      "overlay_female_mutation_hair_short_over_eye_var_green"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_green"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_pink",
+      "overlay_female_mutation_hair_short_over_eye_var_pink"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_pink"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_purple",
+      "overlay_female_mutation_hair_short_over_eye_var_purple"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_purple"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_red",
+      "overlay_female_mutation_hair_short_over_eye_var_red"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_red"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
+    "id": [
+      "overlay_male_mutation_hair_short_over_eye_var_white",
+      "overlay_female_mutation_hair_short_over_eye_var_white"
+    ],
+    "fg": [
+      "overlay_mutation_short_over_eye_var_white"
+    ],
+    "bg": [],
+    "rotates": false
+  },
+  {
     "id": "overlay_male_mutation_hair_short_var_black",
     "fg": [
       "overlay_male_mutation_hair_short_var_black"
@@ -1571,778 +2341,8 @@
   },
   {
     "id": [
-      "overlay_male_mutation_long_over_eye_var_black",
-      "overlay_female_mutation_long_over_eye_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_blond",
-      "overlay_female_mutation_long_over_eye_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_blue",
-      "overlay_female_mutation_long_over_eye_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_brown",
-      "overlay_female_mutation_long_over_eye_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_gray",
-      "overlay_female_mutation_long_over_eye_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_green",
-      "overlay_female_mutation_long_over_eye_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_pink",
-      "overlay_female_mutation_long_over_eye_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_purple",
-      "overlay_female_mutation_long_over_eye_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_red",
-      "overlay_female_mutation_long_over_eye_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_long_over_eye_var_white",
-      "overlay_female_mutation_long_over_eye_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_long_over_eye_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_black",
-      "overlay_female_mutation_messy_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_blond",
-      "overlay_female_mutation_messy_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_blue",
-      "overlay_female_mutation_messy_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_brown",
-      "overlay_female_mutation_messy_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_gray",
-      "overlay_female_mutation_messy_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_green",
-      "overlay_female_mutation_messy_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_pink",
-      "overlay_female_mutation_messy_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_purple",
-      "overlay_female_mutation_messy_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_red",
-      "overlay_female_mutation_messy_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_messy_var_white",
-      "overlay_female_mutation_messy_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_messy_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_black",
-      "overlay_female_mutation_modern_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_blond",
-      "overlay_female_mutation_modern_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_blue",
-      "overlay_female_mutation_modern_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_brown",
-      "overlay_female_mutation_modern_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_gray",
-      "overlay_female_mutation_modern_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_green",
-      "overlay_female_mutation_modern_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_pink",
-      "overlay_female_mutation_modern_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_purple",
-      "overlay_female_mutation_modern_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_red",
-      "overlay_female_mutation_modern_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_modern_var_white",
-      "overlay_female_mutation_modern_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_modern_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_black",
-      "overlay_female_mutation_mullet_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_blond",
-      "overlay_female_mutation_mullet_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_blue",
-      "overlay_female_mutation_mullet_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_brown",
-      "overlay_female_mutation_mullet_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_gray",
-      "overlay_female_mutation_mullet_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_green",
-      "overlay_female_mutation_mullet_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_pink",
-      "overlay_female_mutation_mullet_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_purple",
-      "overlay_female_mutation_mullet_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_red",
-      "overlay_female_mutation_mullet_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_mullet_var_white",
-      "overlay_female_mutation_mullet_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_mullet_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_black",
-      "overlay_female_mutation_ponytail_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_blond",
-      "overlay_female_mutation_ponytail_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_blue",
-      "overlay_female_mutation_ponytail_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_brown",
-      "overlay_female_mutation_ponytail_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_gray",
-      "overlay_female_mutation_ponytail_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_green",
-      "overlay_female_mutation_ponytail_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_pink",
-      "overlay_female_mutation_ponytail_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_purple",
-      "overlay_female_mutation_ponytail_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_red",
-      "overlay_female_mutation_ponytail_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_ponytail_var_white",
-      "overlay_female_mutation_ponytail_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_ponytail_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_black",
-      "overlay_female_mutation_short_no_fringe_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_blond",
-      "overlay_female_mutation_short_no_fringe_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_blue",
-      "overlay_female_mutation_short_no_fringe_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_brown",
-      "overlay_female_mutation_short_no_fringe_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_gray",
-      "overlay_female_mutation_short_no_fringe_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_green",
-      "overlay_female_mutation_short_no_fringe_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_pink",
-      "overlay_female_mutation_short_no_fringe_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_purple",
-      "overlay_female_mutation_short_no_fringe_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_red",
-      "overlay_female_mutation_short_no_fringe_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_no_fringe_var_white",
-      "overlay_female_mutation_short_no_fringe_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_short_no_fringe_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_black",
-      "overlay_female_mutation_short_over_eye_var_black"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_black"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_blond",
-      "overlay_female_mutation_short_over_eye_var_blond"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_blond"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_blue",
-      "overlay_female_mutation_short_over_eye_var_blue"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_blue"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_brown",
-      "overlay_female_mutation_short_over_eye_var_brown"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_brown"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_gray",
-      "overlay_female_mutation_short_over_eye_var_gray"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_gray"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_green",
-      "overlay_female_mutation_short_over_eye_var_green"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_green"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_pink",
-      "overlay_female_mutation_short_over_eye_var_pink"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_pink"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_purple",
-      "overlay_female_mutation_short_over_eye_var_purple"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_purple"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_red",
-      "overlay_female_mutation_short_over_eye_var_red"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_red"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_short_over_eye_var_white",
-      "overlay_female_mutation_short_over_eye_var_white"
-    ],
-    "fg": [
-      "overlay_mutation_short_over_eye_var_white"
-    ],
-    "bg": [],
-    "rotates": false
-  },
-  {
-    "id": [
-      "overlay_male_mutation_twintails_var_white",
-      "overlay_female_mutation_twintails_var_white"
+      "overlay_male_mutation_hair_twintails_var_white",
+      "overlay_female_mutation_hair_twintails_var_white"
     ],
     "fg": [
       "overlay_mutation_twintails_var_white"


### PR DESCRIPTION
12 hairstyles (buzzcut, curls, detective, long_over_eye, messy, modern, mullet, ponytail, short_no_fringe, short_over_eye, twintails, braid) were
  invisible in-game because their overlay ids were missing the required hair_ prefix (e.g. overlay_male_mutation_messy_var_black instead of
  overlay_male_mutation_hair_messy_var_black), inherited from an inconsistency in the source art. Fixed 121 entries in hair.json.